### PR TITLE
Fix mismatched parameters in experiment

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -31,8 +31,6 @@ n_loops = 10
 n_mini_loops_gen = 1
 n_mini_loops_pred = 1
 n_batch = 200
-layer_weights_normed = False
-loss_gen_reg_coeff = 10.0
 weight_decay_gen = 0.0
 weight_decay_pred = 1e-4
 lr_gen = 0.1
@@ -192,8 +190,6 @@ results = the_hunt(
         deer,
         puma,
         loss_func,
-        loss_gen_reg_coeff,
-        layer_weights_normed,
         cost,
         eps,
         dust_const,


### PR DESCRIPTION
## Summary
- clean unused hyperparameters
- fix `the_hunt` call in `experiment.py` to match train module

## Testing
- `python -m py_compile experiment.py src/train.py src/nets.py src/sinkhorn.py`


------
https://chatgpt.com/codex/tasks/task_e_683f43a60d2883218253efc82d8af707