### PR TITLE
docs: clarify sink_vec returns both U and V

### DIFF
--- a/src/sinkhorn.py
+++ b/src/sinkhorn.py
@@ -107,6 +107,8 @@ def sink_vec(MU : torch.Tensor, NU : torch.Tensor, C : torch.Tensor,
     
     Returns
     -------
+    U : (n_samples, dim) torch.Tensor
+        1st Scaling factor.
     V : (n_samples, dim) torch.Tensor
         2nd Scaling factor.
     """


### PR DESCRIPTION
## Summary
- update sinkhorn.sink_vec docstring to show both U and V are returned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683f45895c0c83218ee743220d943184