### PR TITLE
Fix NaN masking in training loop

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -145,7 +145,7 @@ def the_hunt(
                     U = torch.log(U)
                     V = torch.log(V)
 
-                nan_mask = ~(torch.isnan(U).any(dim=1) & torch.isnan(
+                nan_mask = ~(torch.isnan(U).any(dim=1) | torch.isnan(
                     V).any(dim=1)).to(device)
                 non_nan_total = nan_mask.sum().item()
 
@@ -189,7 +189,7 @@ def the_hunt(
                         U = torch.log(U)
                         V = torch.log(V)
 
-                    nan_mask = ~(torch.isnan(U).any(dim=1) & torch.isnan(
+                    nan_mask = ~(torch.isnan(U).any(dim=1) | torch.isnan(
                         V).any(dim=1)).to(device)
 
                 X_gen = X[nan_mask]


### PR DESCRIPTION
## Summary
- drop all NaN samples when U or V contain NaNs while training

## Testing
- `python -m py_compile src/train.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4588c8e08321a9a20a3c8d8681ca